### PR TITLE
Warn should used in multi line block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,43 @@
+inherit_from: .rubocop_todo.yml
+
+require:
+  - rubocop-bitjourney
+
+AllCops:
+  Exclude:
+    - vendor/**/*
+    - db/**/*
+    - bin/**
+  RunRailsCops: true
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FileName:
+  Exclude:
+    - lib/rubocop-bitjourney.rb
+
+Style/NumericLiterals:
+  MinDigits: 10
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%': '{}'
+
+Style/SignalException:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,7 @@ require:
 
 AllCops:
   Exclude:
-    - vendor/**/*
-    - db/**/*
     - bin/**
-  RunRailsCops: true
 
 Lint/AssignmentInCondition:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,3 @@
+# Offense count: 10
+Metrics/AbcSize:
+  Max: 59

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,7 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
 task default: :spec

--- a/lib/rubocop/bitjourney/cop/rspec/is_expected_to.rb
+++ b/lib/rubocop/bitjourney/cop/rspec/is_expected_to.rb
@@ -15,9 +15,13 @@ module RuboCop
         def on_block(node)
           _method, _args, body = *node
           _receiver, property_name, *_args = *body
-          if property_name == :should
-            add_offense(node, :expression, MSG)
-          end
+          return unless property_name == :should
+
+          expr = body.loc.expression
+          bp = expr.begin_pos
+          ep = expr.end_pos
+          range = Parser::Source::Range.new(expr.source_buffer, bp, ep)
+          add_offense(node, range, MSG)
         end
       end
     end

--- a/rubocop-bitjourney.gemspec
+++ b/rubocop-bitjourney.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'pry'
 end

--- a/rubocop-bitjourney.gemspec
+++ b/rubocop-bitjourney.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Masahiro Ihara']
   spec.email         = ['ihara@bitjourney.com']
 
-  spec.summary       = %q{Custom cop for bitjourney projects}
-  spec.description   = %q{Custom cop for bitjourney projects}
+  spec.summary       = 'Custom cop for bitjourney projects'
+  spec.description   = 'Custom cop for bitjourney projects'
   spec.homepage      = 'http://github.com/bitjourney/ruboty-bitjourney'
   spec.license       = 'MIT'
 

--- a/spec/rubocop/cop/rspec/is_expected_to_spec.rb
+++ b/spec/rubocop/cop/rspec/is_expected_to_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe RuboCop::Cop::RSpec::IsExpectedTo do
   subject(:cop) { described_class.new }

--- a/spec/rubocop/cop/rspec/is_expected_to_spec.rb
+++ b/spec/rubocop/cop/rspec/is_expected_to_spec.rb
@@ -3,9 +3,29 @@ require 'spec_helper'
 describe RuboCop::Cop::RSpec::IsExpectedTo do
   subject(:cop) { described_class.new }
 
-  it 'prefers using is_expected.to to should' do
-    inspect_source(cop, 'it { should be_valid }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq ['Prefer `is_expected.to` to `should`.']
+  shared_examples_for 'preferring is_expected.to' do
+    it 'prefers using is_expected.to to should' do
+      inspect_source(cop, code)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq ['Prefer `is_expected.to` to `should`.']
+    end
+  end
+
+  context 'with one liner' do
+    let(:code) { 'it { should be_valid }' }
+
+    it_behaves_like 'preferring is_expected.to'
+  end
+
+  context 'with multiple lines' do
+    let(:code) do
+      <<-EOS
+it '' do
+  should be_valid
+end
+      EOS
+    end
+
+    it_behaves_like 'preferring is_expected.to'
   end
 end


### PR DESCRIPTION
``` ruby
it '' do
  should be_valid
end
```

みたいな場合もソースの位置をきちんと警告してくれるように変更しました。

![screen shot 2015-06-16 at 4 55 08 pm](https://cloud.githubusercontent.com/assets/31079/8178632/06062308-144b-11e5-8d70-4bb40acecf52.png)

その他、rubocopの導入、pryの削除等をやっております。
とりあえずこれだけでもkintanに入れて良いかも。

@dex1t 文法のパーサのところは僕も合っていない気がしていますが、、レビューお願いします〜 :bow: 
